### PR TITLE
Copy wallet address + Total connected peers

### DIFF
--- a/qortal-ui-plugins/plugins/core/components/ButtonIconCopy.js
+++ b/qortal-ui-plugins/plugins/core/components/ButtonIconCopy.js
@@ -10,6 +10,8 @@ class ButtonIconCopy extends LitElement {
         return {
             textToCopy: { type: String },
             title: { type: String },
+            onSuccessMessage: { type: String },
+            onErrorMessage: { type: String },
             buttonSize: { type: String },
             iconSize: { type: String },
             color: { type: String },
@@ -22,6 +24,8 @@ class ButtonIconCopy extends LitElement {
         super()
         this.textToCopy = ''
         this.title = 'Copy to clipboard'
+        this.onSuccessMessage = 'Copied to clipboard'
+        this.onErrorMessage = 'Unable to copy'
         this.buttonSize = '48px'
         this.iconSize = '24px'
         this.color = 'inherit'
@@ -53,10 +57,10 @@ class ButtonIconCopy extends LitElement {
     async saveToClipboard(text) {
         try {
             await navigator.clipboard.writeText(text)
-            parentEpml.request('showSnackBar', 'Address copied to clipboard')
+            parentEpml.request('showSnackBar', this.onSuccessMessage)
         } catch (err) {
-            parentEpml.request('showSnackBar', 'Unable to copy address')
-            console.error('Unable to copy address', err)
+            parentEpml.request('showSnackBar', this.onErrorMessage)
+            console.error('Copy to clipboard error:', err)
         }
     }
 }

--- a/qortal-ui-plugins/plugins/core/components/ButtonIconCopy.js
+++ b/qortal-ui-plugins/plugins/core/components/ButtonIconCopy.js
@@ -1,0 +1,64 @@
+import { LitElement, html, css } from 'lit-element'
+import { Epml } from '../../../epml.js'
+
+import '@material/mwc-icon-button'
+
+const parentEpml = new Epml({ type: 'WINDOW', source: window.parent })
+
+class ButtonIconCopy extends LitElement {
+    static get properties() {
+        return {
+            textToCopy: { type: String },
+            title: { type: String },
+            buttonSize: { type: String },
+            iconSize: { type: String },
+            color: { type: String },
+            offsetLeft: { type: String },
+            offsetRight: { type: String }
+        }
+    }
+
+    constructor() {
+        super()
+        this.textToCopy = ''
+        this.title = 'Copy to clipboard'
+        this.buttonSize = '48px'
+        this.iconSize = '24px'
+        this.color = 'inherit'
+        this.offsetLeft = '0'
+        this.offsetRight = '0'
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.style.setProperty('--mdc-icon-button-size', this.buttonSize)
+        this.style.setProperty('--mdc-icon-size', this.iconSize)
+        this.style.setProperty('color', this.color)
+        this.style.setProperty('margin-left', this.offsetLeft)
+        this.style.setProperty('margin-right', this.offsetRight)
+    }
+
+    render() {
+        return html`
+            <mwc-icon-button 
+                title=${this.title}
+                label=${this.title}
+                icon="content_copy" 
+                @click=${() => this.saveToClipboard(this.textToCopy)}
+            >
+            </mwc-icon-button>
+        `
+    }
+
+    async saveToClipboard(text) {
+        try {
+            await navigator.clipboard.writeText(text)
+            parentEpml.request('showSnackBar', 'Address copied to clipboard');
+        } catch (err) {
+            parentEpml.request('showSnackBar', 'Unable to copy address');
+            console.error('Unable to copy address', err)
+        }
+    }
+}
+
+window.customElements.define('button-icon-copy', ButtonIconCopy)

--- a/qortal-ui-plugins/plugins/core/components/ButtonIconCopy.js
+++ b/qortal-ui-plugins/plugins/core/components/ButtonIconCopy.js
@@ -53,9 +53,9 @@ class ButtonIconCopy extends LitElement {
     async saveToClipboard(text) {
         try {
             await navigator.clipboard.writeText(text)
-            parentEpml.request('showSnackBar', 'Address copied to clipboard');
+            parentEpml.request('showSnackBar', 'Address copied to clipboard')
         } catch (err) {
-            parentEpml.request('showSnackBar', 'Unable to copy address');
+            parentEpml.request('showSnackBar', 'Unable to copy address')
             console.error('Unable to copy address', err)
         }
     }

--- a/qortal-ui-plugins/plugins/core/node-management/node-management.src.js
+++ b/qortal-ui-plugins/plugins/core/node-management/node-management.src.js
@@ -102,28 +102,28 @@ class NodeManagement extends LitElement {
     `;
   }
 
-    constructor() {
-        super();
-        this.upTime = "";
-        this.mintingAccounts = [];
-        this.peers = [];
-        this.addPeerLoading = false;
-        this.confPeerLoading = false;
-        this.addMintingAccountLoading = false;
-        this.removeMintingAccountLoading = false;
-        this.addMintingAccountKey = "";
-        this.addPeerMessage = "";
-        this.confPeerMessage = "";
-        this.addMintingAccountMessage = "";
-        this.tempMintingAccount = {};
-        this.config = {
-            user: {
-                node: {},
-            },
-        };
-        this.nodeConfig = {};
-        this.nodeDomain = "";
-    }
+  constructor() {
+      super();
+      this.upTime = "";
+      this.mintingAccounts = [];
+      this.peers = [];
+      this.addPeerLoading = false;
+      this.confPeerLoading = false;
+      this.addMintingAccountLoading = false;
+      this.removeMintingAccountLoading = false;
+      this.addMintingAccountKey = "";
+      this.addPeerMessage = "";
+      this.confPeerMessage = "";
+      this.addMintingAccountMessage = "";
+      this.tempMintingAccount = {};
+      this.config = {
+          user: {
+              node: {},
+          },
+      };
+      this.nodeConfig = {};
+      this.nodeDomain = "";
+  }
 
   render() {
     return html`
@@ -131,7 +131,7 @@ class NodeManagement extends LitElement {
         <div class="node-card">
           <h2>Node management for: ${this.nodeDomain}</h2>
           <span><br />Node has been online for: ${this.upTime}</span>
-
+          
           <br /><br />
           <div id="minting">
             <div style="min-height:48px; display: flex; padding-bottom: 6px;">
@@ -143,9 +143,9 @@ class NodeManagement extends LitElement {
               <mwc-button
                 style="float:right;"
                 @click=${() =>
-        this.shadowRoot
-          .querySelector("#addMintingAccountDialog")
-          .show()}
+                  this.shadowRoot
+                    .querySelector("#addMintingAccountDialog")
+                    .show()}
                 ><mwc-icon>add</mwc-icon>Add minting account</mwc-button
               >
             </div>
@@ -215,7 +215,10 @@ class NodeManagement extends LitElement {
           <br />
           <div id="peers">
             <div style="min-height: 48px; display: flex; padding-bottom: 6px;">
-              <h3 style="margin: 0; flex: 1; padding-top: 8px; display: inline;">Peers connected to node</h3>
+              <h3 style="margin: 0; flex: 1; padding-top: 8px; display: inline;">
+                <span>Peers connected to node</span>
+                <span>(${this.peers.length})</span>
+              </h3>
               <mwc-button @click=${() => this.shadowRoot.querySelector("#addPeerDialog").show()}><mwc-icon>add</mwc-icon>Add peer</mwc-button>
             </div>
 
@@ -255,7 +258,7 @@ class NodeManagement extends LitElement {
                 <vaadin-grid-column path="lastHeight"></vaadin-grid-column>
                 <vaadin-grid-column path="version" header="Build Version"></vaadin-grid-column>
                 <vaadin-grid-column path="age" header="Connected for"></vaadin-grid-column>
-				<vaadin-grid-column  width="12em" header="Action" .renderer=${(root, column, data) => {
+				        <vaadin-grid-column  width="12em" header="Action" .renderer=${(root, column, data) => {
                     render(html`<mwc-button class="red" @click=${() => this.removePeer(data.item.address, data.index)}><mwc-icon>delete</mwc-icon>Remove Peer</mwc-button>`, root)
                 }}></vaadin-grid-column>
             </vaadin-grid>

--- a/qortal-ui-plugins/plugins/core/wallet/wallet-app.src.js
+++ b/qortal-ui-plugins/plugins/core/wallet/wallet-app.src.js
@@ -2,6 +2,8 @@ import { LitElement, html, css } from 'lit-element'
 import { render } from 'lit-html'
 import { Epml } from '../../../epml.js'
 
+import '../components/ButtonIconCopy'
+
 import '@material/mwc-icon'
 import '@material/mwc-button'
 import '@material/mwc-dialog'
@@ -217,12 +219,7 @@ class MultiWallet extends LitElement {
 					height: 100vh;
 					border-top-left-radius: inherit;
 					border-bottom-left-radius: inherit;
-    			border-right: 1px solid #eee;
-				}
-
-				.wallet-header {
-					margin: 0 50px;
-					display: flex;
+    				border-right: 1px solid #eee;
 				}
 
 				.transactions-wrapper {
@@ -231,11 +228,23 @@ class MultiWallet extends LitElement {
 					height: 100%;
 				}
 
-				.total-balance {
+				.wallet-header {
+					margin: 0 20px;
+				}
+
+				.wallet-address {
+					display: flex;
+					align-items: center;
+					font-size: 18px; 
+					color: var(--mdc-theme-primary, #444750); 
+					margin: 4px 0 20px;
+				}
+
+				.wallet-balance {
 					display: inline-block;
 					font-weight: 600;
 					font-size: 32px;
-					color: #444750;
+					color: var(--mdc-theme-primary, #444750); 
 				}
 
 				#transactions {
@@ -446,7 +455,7 @@ class MultiWallet extends LitElement {
 					.currency-box:last-of-type {
 						margin-bottom: 0;
 					}
-					.total-balance {
+					.wallet-balance {
 						font-size: 22px;
 					}
 				}
@@ -548,12 +557,20 @@ class MultiWallet extends LitElement {
 
 				<div class="transactions-wrapper">
 					<h2 class="wallet-header">
-						<div class="">
-							Current Wallet
-							<br />
-							<span style="display: block; font-size: 18px; color: rgb(68, 71, 80); margin-bottom: 6px;"> ${this._selectedWallet === 'qort' ? this.wallets.get(this._selectedWallet).wallet.address : this.wallets.get(this._selectedWallet).wallet.address} </span>
-							<span class="total-balance"> ${this.balanceString}</span>
+						Current Wallet
+						<div class="wallet-address">
+							<span>${this.getSelectedWalletAddress()}</span>
+							<button-icon-copy 
+								title="Copy wallet address to clipboard" 
+								textToCopy=${this.getSelectedWalletAddress()}
+								buttonSize="28px"
+								iconSize="16px"
+								color="#707584"
+								offsetLeft="4px"
+							>
+							</button-icon-copy> 
 						</div>
+						<span class="wallet-balance">${this.balanceString}</span>
 					</h2>
 					<div id="transactions">
 						${this.loading ? html`<paper-spinner-lite style="display: block; margin: 0 auto;" active></paper-spinner-lite>` : ''}
@@ -608,6 +625,13 @@ class MultiWallet extends LitElement {
 			</div>
 		`
 	}
+
+	getSelectedWalletAddress() {
+		return this._selectedWallet === 'qort'
+			? this.wallets.get(this._selectedWallet).wallet.address
+			: this.wallets.get(this._selectedWallet).wallet.address
+	}
+		
 
 	async getTransactionGrid(coin) {
 		this.transactionsGrid = this.shadowRoot.querySelector(`#${coin}TransactionsGrid`)

--- a/qortal-ui-plugins/plugins/core/wallet/wallet-app.src.js
+++ b/qortal-ui-plugins/plugins/core/wallet/wallet-app.src.js
@@ -561,7 +561,9 @@ class MultiWallet extends LitElement {
 						<div class="wallet-address">
 							<span>${this.getSelectedWalletAddress()}</span>
 							<button-icon-copy 
-								title="Copy wallet address to clipboard" 
+								title="Copy wallet address to clipboard"
+								onSuccessMessage="Address copied to clipboard"
+								onErrorMessage="Unable to copy address"
 								textToCopy=${this.getSelectedWalletAddress()}
 								buttonSize="28px"
 								iconSize="16px"


### PR DESCRIPTION
This PR solves the following tickets from the kanban board:

- [Add 'copy address' button to wallets](https://github.com/orgs/Qortal/projects/1#card-66609727):
- [Add 'total connected peer' count in Node Management](https://github.com/orgs/Qortal/projects/1#card-69060953). - Note: I had a PR open for this one but I closed it since it was from my main branch and Included it here since it's a pretty small change (one line of code + some tab formatting that was off). It basically adds the total number of connected peers between brackets to the section title in node management.

For the copy button I created a reusable component so that it can be added to other places as well if we need it.
It uses the Material UI <mwc-icon-button /> do display a button with the content_copy icon and supports the following properties:
- **textToCopy** {string}: the string that will be copied to the clipboard.
- **title** {string}: the text that will be used in the system's tooltip on hover (title) and as the aria-label property.
- **onSuccessMessage** {string}: message shown in the snackbar when text is successfully copied to clipboard.
- **onErrorMessage** {string}: message shown in the snackbar when text is NOT successfully copied to clipboard.
- **color** {string}: the color of the button icon. It's a string to support hex/rgb/rgba/etc.
- **buttonSize** {string}: size of the actual button (includes the 'ripple' that's visible on hover). It's a string instead of number to support px/em/rem etc (this is valid for the following props as well).
- **iconSize** {string}: size of the icon at the center of the button.
- **offsetLeft** {string}: left margin. Useful when appending the button to the right of an element.
- **offsetRight** {string}: right margin. Useful when appending the button to the left of an element.

The component can be extended further, for example adding a **isIconOnly** {boolean} property with which we could choose to render the button as it is now (only an icon) or an actual button with text.

Some screenshots:

- Copy button in wallet:
![image](https://user-images.githubusercontent.com/30963185/134214692-f52bb8da-7d55-4355-8aa4-3b4d8b25f505.png)

- Copy button on hover (screengrab doesn't show cursor pointer):
![image](https://user-images.githubusercontent.com/30963185/134214436-1b610027-4f6c-45c7-9ea5-a89a270173c2.png)

- On copy success:
![image](https://user-images.githubusercontent.com/30963185/134215626-77aed257-a64a-4bbb-a20b-911c960e5123.png)

- Connected peers in node management:
![image](https://user-images.githubusercontent.com/30963185/134216042-ff6b45da-73dc-4a25-810c-3702aab458b3.png)

-------------
P.S. Please someone, test thoroughly. I tested on my side both in a couple of browsers and the standalone app (on Win10), but developer tunnel vision and all that...
